### PR TITLE
 additions to vectors/fintypes

### DIFF
--- a/FiniteTypes/FinTypes.v
+++ b/FiniteTypes/FinTypes.v
@@ -121,6 +121,20 @@ Proof.
   -repeat destruct Dec;intuition; congruence.
 Qed.
 
+Lemma getPosition_nth (X:eqType) k (d :X) xs:
+  Dupfree.dupfree xs ->
+  k < length xs ->
+  getPosition xs (nth k xs d) = k.
+Proof.
+  induction xs in k|-*. now cbn.
+  intros H1 H2. inv H1.
+  cbn. destruct k.
+  -decide _. all:easy.
+  -decide _.
+   +subst a. cbn in H2. edestruct H3. eapply nth_In. omega.
+   + cbn in H2. rewrite IHxs. all:try easy;omega.
+Qed.
+
 Definition pos_def (X : eqType) (x : X) A n :=  match pos x A with None => n | Some n => n end. 
 
 Definition index {F: finType} (x:F) := getPosition (elem F) x.
@@ -140,10 +154,19 @@ Proof.
     hnf. intros. now rewrite index_nth.
 Qed.
 
-Lemma index_leq (A:finType) (x:A): index x <= length (elem A).
+Lemma index_le (A:finType) (x:A): index x < length (elem A).
 Proof.
   unfold index.
-  generalize (elem A) . intros l.
+  assert (H:x el elem A) by apply elem_spec.
+  revert H.
+  generalize (elem A). intros l H.
   induction l;cbn;[|decide _].
-  all:omega.
+  -easy.
+  -omega.
+  -destruct H. congruence. apply IHl in H. omega.
+Qed.
+
+Lemma index_leq (A:finType) (x:A): index x <= length (elem A).
+Proof.
+  eapply Nat.lt_le_incl,index_le.
 Qed.

--- a/FiniteTypes/FiniteFunction.v
+++ b/FiniteTypes/FiniteFunction.v
@@ -45,6 +45,22 @@ Proof.
     dec; cbn in *; subst; firstorder.
 Qed.
 
+Lemma lookup_complete (A: eqType) (B: Type) (L : list (prod A B)) a def :
+  {(a,lookup L a def) el L } + {~(exists b, (a,b) el L) /\ lookup L a def  = def}.
+Proof.
+  unfold lookup.
+  destruct filter eqn:E.
+  - right. split. 2:easy.
+    intros (x&?).
+    assert ((a,x) el filter (fun p : A * B => Dec (fst p = a)) L).
+    {rewrite in_filter_iff;cbn. decide _;try easy. }
+    rewrite E in H0. easy. 
+  - assert (p el (filter (fun p : A * B => Dec (fst p = a)) L)) by now rewrite E.
+    rewrite in_filter_iff in H.
+    destruct p.
+    dec; cbn in *; subst; firstorder.
+Qed.
+
 Lemma finfunc_correct (A: finType) B (f: A -> B) a  def: lookup (finfunc_table f) a def = f a.
 Proof.
   eapply lookup_sound; [ apply finfunc_sound_cor | apply finfunc_comp ].

--- a/FiniteTypes/VectorFin.v
+++ b/FiniteTypes/VectorFin.v
@@ -25,6 +25,8 @@ Definition Fin_initVect_nth (n : nat) (k : Fin.t n) :
   Vector.nth (Fin_initVect n) k = k.
 Proof. unfold Fin_initVect. apply nth_tabulate. Qed.
 
+Import VecToListCoercion.
+
 Instance Fin_finTypeC n : finTypeC (EqType (Fin.t n)).
 Proof.
   constructor 1 with (enum := Fin_initVect n).
@@ -33,6 +35,7 @@ Proof.
   - eapply tolist_dupfree. apply Fin_initVect_dupfree.
   - eapply tolist_In. apply Fin_initVect_full.
 Qed.
+
 
 (** Function that produces a list of all Vectors of length n over A *)
 Fixpoint Vector_pow {X: Type} (A: list X) n {struct n} : list (Vector.t X n) :=

--- a/Vectors/VectorDupfree.v
+++ b/Vectors/VectorDupfree.v
@@ -10,6 +10,7 @@ Require Import Coq.Vectors.Vector.
 
 Open Scope vector_scope.
 
+
 Inductive dupfree X : forall n, Vector.t X n -> Prop :=
   dupfreeVN :
     dupfree (@Vector.nil X)
@@ -84,6 +85,8 @@ Proof.
   - cbn. constructor.
   - cbn. constructor; auto. now intros (? & -> % HInj & ?) % vect_in_map_iff.
 Qed.
+
+Import VecToListCoercion.
 
 Lemma tolist_dupfree (X : Type) (n : nat) (xs : Vector.t X n) :
   dupfree xs -> Dupfree.dupfree xs.

--- a/Vectors/Vectors.v
+++ b/Vectors/Vectors.v
@@ -378,8 +378,11 @@ Proof. intros H. simpl_vector_in. Qed.
 
 
 (** Conversion between vectors and lists *)
+Module VecToListCoercion.
+  Coercion Vector.to_list : Vector.t >-> list.
+End VecToListCoercion.
 
-Coercion Vector.to_list : Vector.t >-> list.
+Import VecToListCoercion.
 
 Lemma tolist_In (X : Type) (n : nat) (xs : Vector.t X n) (x : X) :
   Vector.In x xs <-> List.In x xs.
@@ -398,3 +401,11 @@ Proof with try (constructor;congruence).
   intros Hf x y.
   apply iff_reflect. symmetry. apply Vector.eqb_eq. symmetry. apply reflect_iff. eauto.
 Qed. 
+
+Lemma vector_to_list_inj (X : Type) (n : nat) (xs ys : Vector.t X n) :
+  Vector.to_list xs = Vector.to_list ys -> xs = ys.
+Proof.
+  revert ys. induction xs as [ | x n xs IH]; intros; cbn in *.
+  - destruct_vector. reflexivity.
+  - destruct_vector. cbn in *. inv H. f_equal. auto.
+Qed.


### PR DESCRIPTION
-small, backwards compatible additions to fintype/vector lemmas
-hide the vector-to-list coercion in a module