### PR TITLE
Make Fin.t finType instance transparent + small lemmas

### DIFF
--- a/FiniteTypes/VectorFin.v
+++ b/FiniteTypes/VectorFin.v
@@ -35,8 +35,9 @@ Proof.
   eapply dupfreeCount.
   - eapply tolist_dupfree. apply Fin_initVect_dupfree.
   - eapply tolist_In. apply Fin_initVect_full.
-Qed.
+Defined.
 
+Hint Extern 4 (finTypeC (EqType (Fin.t _))) => eapply Fin_finTypeC : typeclass_instances.
 
 (** Function that produces a list of all Vectors of length n over A *)
 Fixpoint Vector_pow {X: Type} (A: list X) n {struct n} : list (Vector.t X n) :=

--- a/FiniteTypes/VectorFin.v
+++ b/FiniteTypes/VectorFin.v
@@ -3,6 +3,7 @@ Require Import PslBase.FiniteTypes.FinTypes.
 Require Import PslBase.Vectors.Vectors.
 Require Import PslBase.Vectors.VectorDupfree.
 Import VectorNotations2.
+Require Import PslBase.FiniteTypes.Cardinality.
 
 Definition Fin_initVect (n : nat) : Vector.t (Fin.t n) n :=
   tabulate (fun i : Fin.t n => i).
@@ -38,6 +39,11 @@ Proof.
 Defined.
 
 Hint Extern 4 (finTypeC (EqType (Fin.t _))) => eapply Fin_finTypeC : typeclass_instances.
+
+Lemma Fin_cardinality n : Cardinality (finType_CS (Fin.t n)) = n.
+Proof.
+  unfold Cardinality, elem, enum. cbn. unfold Fin_initVect. now rewrite vector_to_list_length. 
+Qed.
 
 (** Function that produces a list of all Vectors of length n over A *)
 Fixpoint Vector_pow {X: Type} (A: list X) n {struct n} : list (Vector.t X n) :=

--- a/Vectors/Vectors.v
+++ b/Vectors/Vectors.v
@@ -416,3 +416,11 @@ Proof.
   - destruct_vector. reflexivity.
   - destruct_vector. cbn in *. inv H. f_equal. auto.
 Qed.
+
+Lemma vector_to_list_length (X : Type) (n : nat) (xs : Vector.t X n) :
+  length(Vector.to_list xs) = n. 
+Proof.
+  induction xs as [ | x n xs IH]. 
+  - now cbn. 
+  - change (S (length xs) = S n). congruence.
+Qed. 


### PR DESCRIPTION
This contains a few small additions that my Bachelor's project depends on. 
The most relevant one is to make the definition of the finType instance of `Fin.t` transparent, which is needed to prove that the cardinality of `Fin.t n` is actually `n`. 